### PR TITLE
Stream wrapper

### DIFF
--- a/streams/StreamDoc.py
+++ b/streams/StreamDoc.py
@@ -1,0 +1,249 @@
+'''
+    This code is where most of the StreamDoc processing in the application
+    layer should reside. Conversions from other interfaces to StreamDoc are
+    found in corresponding interface folders.
+'''
+from functools import wraps
+
+_MAX_STR_LEN = 72  # Maximum length for string representations of objects
+
+
+class StreamDoc(dict):
+    def __init__(self, streamdoc=None, args=(), kwargs={}, attributes={}):
+        ''' A generalized document meant to be parsed by Streams.
+
+            Components:
+                attributes : the metadata
+                outputs : a dictionary of outputs from stream
+                args : a list of args
+                kwargs : a list of kwargs
+                statistics : some statistics of the stream that generated this
+                    It can be anything, like run_start, run_stop etc
+        '''
+        # TODO : make attributes a separate class with its own get/set and
+        # parsing
+        # TODO : make option whether not attributes should be inherited?
+        # (global attributes). Such an implementation requires a
+        # 'global_attributes' name list
+        # TODO : functions to select, remove replace etc
+        # TODO : join method? join(override=True) for ex where override says
+        # what to do with conflicting attributes
+
+        # initialize
+        self['attributes'] = dict()
+        self['kwargs'] = dict()
+        self['args'] = list()
+        self['statistics'] = dict()
+        # needed to distinguish that it is a StreamDoc by stream methods
+        self['_StreamDoc'] = 'StreamDoc v1.0'
+
+        # update
+        if streamdoc is not None:
+            self.updatedoc(streamdoc)
+
+        # override with args
+        self.add(args=args, kwargs=kwargs, attributes=attributes)
+
+    def updatedoc(self, streamdoc):
+        self.add(args=streamdoc['args'], kwargs=streamdoc['kwargs'],
+                 attributes=streamdoc['attributes'],
+                 statistics=streamdoc['statistics'])
+
+    def add(self, args=[], kwargs={}, attributes={}, statistics={}):
+        ''' add args and kwargs'''
+        if not isinstance(args, list) and not isinstance(args, tuple):
+            args = (args, )
+
+        self['args'].extend(args)
+        # Note : will overwrite previous kwarg data without checking
+        self['kwargs'].update(kwargs)
+        self['attributes'].update(attributes)
+        self['statistics'].update(statistics)
+
+    @property
+    def args(self):
+        return self['args']
+
+    @property
+    def kwargs(self):
+        return self['kwargs']
+
+    @property
+    def attributes(self):
+        return self['attributes']
+
+    @property
+    def statistics(self):
+        return self['statistics']
+
+    def get_return(self, elem=None):
+        ''' get what the function would have normally returned.
+
+            returns raw data
+            Parameters
+            ----------
+            elem : optional
+                if an integer: get that nth argumen
+                if a string : get that kwarg
+        '''
+        if isinstance(elem, int):
+            res = self['args'][elem]
+        elif isinstance(elem, str):
+            res = self['kwargs'][elem]
+        elif elem is None:
+            # return general expected function output
+            if len(self['args']) == 0 and len(self['kwargs']) > 0:
+                res = dict(self['kwargs'])
+            elif len(self['args']) > 0 and len(self['kwargs']) == 0:
+                res = self['args']
+                if len(res) == 1:
+                    # a function with one arg normally returns this way
+                    res = res[0]
+            else:
+                # if it's more complex, then it wasn't a function output
+                res = self
+
+        return res
+
+    # TODO : allow partial remapping both for args and kwargs
+    def select(self, mapping):
+        ''' remap args and kwargs
+            combinations can be any one of the following:
+
+
+            Some examples:
+
+            (1,)        : map 1st arg to next available arg
+            (1, None)   : map 1st arg to next available arg
+            'a',        : map 'a' to 'a'
+            'a', None   : map 'a' to next available arg
+            'a','b'     : map 'a' to 'b'
+            1, 'a'      : map 1st arg to 'a'
+
+            The following is NOT accepted:
+            (1,2) : this would map arg 1 to arg 2. Use proper ordering instead
+            ('a',1) : this would map 'a' to arg 1. Use proper ordering instead
+
+            Notes
+            -----
+            These *must* be tuples, and the list a list kwarg elems must be
+                strs and arg elems must be ints to accomplish this instead
+        '''
+        if not isinstance(mapping, list):
+            mapping = [mapping]
+        streamdoc = StreamDoc(self)
+        newargs = list()
+        newkwargs = dict()
+        totargs = dict(args=newargs, kwargs=newkwargs)
+
+        for mapelem in mapping:
+            # duck-type to figure out if mapelem is a str key or int index
+            if isinstance(mapelem, str):
+                mapelem = mapelem, mapelem
+            elif isinstance(mapelem, int):
+                mapelem = mapelem, None
+
+            # only for strings
+            if len(mapelem) == 1 and isinstance(mapelem[0], str):
+                mapelem = mapelem[0], mapelem[0]
+            elif len(mapelem) == 1 and isinstance(mapelem[0], int):
+                mapelem = mapelem[0], None
+
+            oldkey = mapelem[0]
+            newkey = mapelem[1]
+
+            if isinstance(oldkey, int):
+                oldparentkey = 'args'
+            elif isinstance(oldkey, str):
+                oldparentkey = 'kwargs'
+
+            if newkey is None:
+                newparentkey = 'args'
+            elif isinstance(newkey, str):
+                newparentkey = 'kwargs'
+            elif isinstance(newkey, int):
+                raise ValueError("Integer tuple pairs not accepted")
+
+            if newparentkey == 'args':
+                totargs[newparentkey].append(streamdoc[oldparentkey][oldkey])
+            else:
+                totargs[newparentkey][newkey] = streamdoc[oldparentkey][oldkey]
+
+        streamdoc['args'] = totargs['args']
+        streamdoc['kwargs'] = totargs['kwargs']
+
+        return streamdoc
+
+
+def _is_streamdoc(doc):
+    if isinstance(doc, dict) and '_StreamDoc' in doc:
+        return True
+    else:
+        return False
+
+
+def parse_streamdoc(name):
+    ''' Decorator to parse StreamDocs from functions
+
+    This is a decorator meant to wrap functions that process streams.
+        It must make the following two assumptions:
+            functions on streams process either one or two arguments:
+                - if processing two arguments, it is assumed that the operation
+                is an accumulation: newstate = f(prevstate, newinstance)
+
+        Generally, this wrapper should be used hand in hand with a type.
+        For example, here, the type is StreamDoc. If a StreamDoc is detected,
+        process the inputs/outputs in a more complicated fashion. Else, leave
+        function untouched.
+
+        output:
+            if a dict, makes a StreamDoc of args where keys are dict elements
+            if a tuple, makes a StreamDoc with only arguments
+            else, makes a StreamDoc of just one element
+    '''
+    def streamdoc_dec(f):
+        @wraps(f)
+        def f_new(x, x2=None, **kwargs_additional):
+            if x2 is None:
+                if _is_streamdoc(x):
+                    # extract the args and kwargs
+                    args = x.args
+                    kwargs = x.kwargs
+                    attributes = x.attributes
+                else:
+                    args = (x,)
+                    kwargs = dict()
+                    attributes = dict()
+            else:
+                if _is_streamdoc(x) and _is_streamdoc(x2):
+                    args = x.get_return(), x2.get_return()
+                    kwargs = dict()
+                    attributes = x.attributes
+                    # attributes of x2 overrides x
+                    attributes.update(x2.attributes)
+                else:
+                    raise ValueError("Two normal arguments not accepted")
+
+            kwargs.update(kwargs_additional)
+
+            # now run the function
+            result = f(*args, **kwargs)
+
+            attributes['function_name'] = f.__name__
+            attributes['stream_name'] = name
+            # instantiate new stream doc
+            streamdoc = StreamDoc(attributes=attributes)
+            # load in attributes
+            # Save outputs to StreamDoc
+            if isinstance(result, dict):
+                # NOTE : Order is not well defined here
+                # TODO : mark in documentation that order is not well defined
+                streamdoc.add(kwargs=result)
+            else:
+                streamdoc.add(args=result)
+
+            return streamdoc
+
+        return f_new
+
+    return streamdoc_dec

--- a/streams/StreamDoc.py
+++ b/streams/StreamDoc.py
@@ -5,10 +5,6 @@
 '''
 from functools import wraps
 
-def select(sdoc, mapping):
-    ''' select outputs from a stream document.'''
-    return sdoc.select(mapping)
-
 class StreamDoc(dict):
     def __init__(self, streamdoc=None, args=(), kwargs={}, attributes={}):
         ''' A generalized document meant to be parsed by Streams.
@@ -21,6 +17,7 @@ class StreamDoc(dict):
                 statistics : some statistics of the stream that generated this
                     It can be anything, like run_start, run_stop etc
         '''
+        super(StreamDoc, self).__init__(self)
         # TODO : make attributes a separate class with its own get/set and
         # parsing
         # TODO : make option whether not attributes should be inherited?
@@ -106,6 +103,15 @@ class StreamDoc(dict):
 
         return res
 
+    def merge(self, newstreamdoc):
+        ''' Merge another streamdoc into this one.
+            The new streamdoc's attributes/args/kwargs will override this one.
+        '''
+        streamdoc = StreamDoc(self)
+        streamdoc.add(args=newstreamdoc['args'], kwargs=newstreamdoc['kwargs'],
+                      attributes=newstreamdoc['attributes'])
+        return streamdoc
+
     # TODO : allow partial remapping both for args and kwargs
     def select(self, mapping):
         ''' remap args and kwargs
@@ -130,6 +136,7 @@ class StreamDoc(dict):
             These *must* be tuples, and the list a list kwarg elems must be
                 strs and arg elems must be ints to accomplish this instead
         '''
+        #print("IN STREAMDOC -> SELECT")
         if not isinstance(mapping, list):
             mapping = [mapping]
         streamdoc = StreamDoc(self)

--- a/streams/StreamDoc.py
+++ b/streams/StreamDoc.py
@@ -5,8 +5,6 @@
 '''
 from functools import wraps
 
-_MAX_STR_LEN = 72  # Maximum length for string representations of objects
-
 
 class StreamDoc(dict):
     def __init__(self, streamdoc=None, args=(), kwargs={}, attributes={}):

--- a/streams/StreamDoc.py
+++ b/streams/StreamDoc.py
@@ -5,6 +5,9 @@
 '''
 from functools import wraps
 
+def select(sdoc, mapping):
+    ''' select outputs from a stream document.'''
+    return sdoc.select(mapping)
 
 class StreamDoc(dict):
     def __init__(self, streamdoc=None, args=(), kwargs={}, attributes={}):
@@ -135,13 +138,12 @@ class StreamDoc(dict):
         totargs = dict(args=newargs, kwargs=newkwargs)
 
         for mapelem in mapping:
-            # duck-type to figure out if mapelem is a str key or int index
             if isinstance(mapelem, str):
                 mapelem = mapelem, mapelem
             elif isinstance(mapelem, int):
                 mapelem = mapelem, None
 
-            # only for strings
+            # length 1 for strings, repeat, for int give None
             if len(mapelem) == 1 and isinstance(mapelem[0], str):
                 mapelem = mapelem[0], mapelem[0]
             elif len(mapelem) == 1 and isinstance(mapelem[0], int):

--- a/streams/core.py
+++ b/streams/core.py
@@ -57,6 +57,8 @@ class Stream(object):
             self._loop = kwargs.get('loop')
         if kwargs.get('wrapper'):
             self._wrapper = kwargs.get('wrapper')
+        else:
+            self._wrapper = None
 
         for child in self.children:
             if child:

--- a/streams/core.py
+++ b/streams/core.py
@@ -61,6 +61,8 @@ class Stream(object):
         for child in self.children:
             if child:
                 child.parents.append(self)
+                # takes the wrapper from latest child, all children must have
+                # same wrapper
                 if child._wrapper is not None:
                     self._wrapper = child._wrapper
 
@@ -333,7 +335,7 @@ class map(Stream):
         if self._wrapper is None:
             self.func = func
         else:
-            self.func = func
+            self.func = self._wrapper("map")(func)
         self.kwargs = kwargs
 
         Stream.__init__(self, child)

--- a/streams/core.py
+++ b/streams/core.py
@@ -8,9 +8,6 @@ from tornado.locks import Condition
 from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.queues import Queue
 
-# decorator to normalize inputs/outputs
-from .StreamDoc import parse_streamdoc
-
 no_default = '--no-default--'
 
 
@@ -336,7 +333,7 @@ class map(Stream):
         if self._wrapper is None:
             self.func = func
         else:
-            self.func = parse_streamdoc("map")(func)
+            self.func = func
         self.kwargs = kwargs
 
         Stream.__init__(self, child)

--- a/streams/core.py
+++ b/streams/core.py
@@ -180,6 +180,21 @@ class Stream(object):
         """
         return sliding_window(n, self)
 
+
+    def multiplex(self, nelems):
+        ''' Multiplex stream into a series of nelems streams.
+
+            Assumes that the emitted value of parent is a tuple
+                of at least length nelems.
+        '''
+        def get_elem(args, elem=None):
+            if elem is None:
+                raise ValueError("Must supply an elem number")
+            return args[elem]
+
+        return [self.map(get_elem, elem=i) for i in range(nelems)]
+
+
     def rate_limit(self, interval):
         """ Limit the flow of data
 
@@ -257,9 +272,9 @@ class Stream(object):
         """
         return unique(self, history=history)
 
-    def zip(self, other):
-        """ Combine two streams together into a stream of tuples """
-        return zip(self, other)
+    def zip(self, *other):
+        """ Combine additional streams together into a stream of tuples """
+        return zip(self, *other)
 
     def to_dask(self):
         """ Convert to a Dask Stream

--- a/streams/tests/test_core.py
+++ b/streams/tests/test_core.py
@@ -336,3 +336,16 @@ def test_unique_history():
     source.emit(1)
 
     assert L == [1, 2, 3, 1]
+
+def test_merge():
+    source = Stream()
+    def foo(a):
+        return a
+    # any operation
+    s1 = source.map(foo)
+    s2 = source.map(foo)
+    s3 = s1.merge(s2)
+    s3.map(print)
+
+    s1.emit(dict(a=2))
+    s2.emit(dict(b=7))

--- a/streams/tests/test_streamdoc.py
+++ b/streams/tests/test_streamdoc.py
@@ -1,6 +1,6 @@
 from nose.tools import assert_raises
 
-from streams.StreamDoc import StreamDoc, parse_streamdoc, _is_streamdoc
+from streams.StreamDoc import StreamDoc, parse_streamdoc, _is_streamdoc, select
 from streams.core import Stream
 
 
@@ -41,6 +41,11 @@ def test_streamdoc_index():
     assert(sdoc.select([('foo', None)])['args'][0] == 'bar')
     assert(sdoc.select([('foo', None), ('a', None)])['args'][1] == 'fdfa')
 
+    # compound selections
+    sdoc1 = sdoc.select([(0, 'foo'), ('foo', None), ('a', None)])
+    assert(sdoc1.select([('foo','bar')])['kwargs']['bar'] == 1)
+    assert(sdoc1.select([(0, 'bar')])['kwargs']['bar'] == 'bar')
+
     assert_raises(ValueError, sdoc.select, ('foo', 1))
     assert_raises(ValueError, sdoc.select, (1, 1))
 
@@ -59,13 +64,15 @@ def test_with_streams():
     def foo(a, b):
         return a + b
 
+    def validate_result(res):
+        assert(res==4)
     # initialize the wrapper to understand streamdocs
     s1 = Stream(wrapper=parse_streamdoc)
     s2 = s1.map(foo)
-    s2.map(print)
-    s2.sink(print)
+    # s2.map(print)
+    s2.sink(validate_result)
 
-    sdoc = StreamDoc(args=[1, 2])
+    sdoc = StreamDoc(args=[2, 2])
 
     s1.emit(sdoc)
 
@@ -75,13 +82,100 @@ def test_with_stream_accumulator():
         ''' here prevstate just assumed an int.'''
         return prevstate + curstate
 
+    def validate_result(res):
+        assert(res == 3)
     # initialize the wrapper to understand streamdocs
     s1 = Stream(wrapper=parse_streamdoc)
     s2 = s1.accumulate(accumfunc)
-    s2.map(print)
+    # for debugging:
+    # s2.map(print)
 
     sdoc = StreamDoc(args=[1])
 
     s1.emit(sdoc)
     s1.emit(sdoc)
+    # not good practice to change streams as its being used but this
+    # is just to validate a result
+    s2.map(validate_result)
+    s1.emit(sdoc)
+
+def test_streamdoc_apply():
+    def myadder(a, b, **kwargs):
+        return a + b
+
+    def print_kwargs(*args, **kwargs):
+        print("args : {}".format(args))
+        print("kwargs : {}".format(kwargs))
+
+    def validate_args(*args, **kwargs):
+        assert(kwargs['foo'] == 3)
+
+    # add two numbers, return, then move returned result to 'foo' in kwarg
+    s1 = Stream(wrapper=parse_streamdoc)
+    s2 = s1.map(myadder)
+    # map zeroth arg to 'foo' in kwarg
+    s3 = s2.apply(select, [(0, 'foo')])
+    # hard coded validation
+    s3.map(validate_args)
+    s3.map(print_kwargs)
+
+    # the sum 1+2 = 3 will go to 'foo' in kwarg
+    sdoc = StreamDoc(args=[1,2], kwargs=dict(g=2))
+
+    s1.emit(sdoc)
+
+def test_on_class():
+    ''' Test that it works on a class with a hidden state.
+        Hidden states can be useful ways to pass data to functions that are not
+        necessarily essential to the calculation. In this case it is, but
+        things like plot linewidth etc for plotting are not.
+    '''
+    class myincrementer:
+        def __init__(self, incby):
+            self.incby = incby
+        def increment(self, a):
+            return a + self.incby
+
+    myacc = myincrementer(3)
+    s1 = Stream(wrapper=parse_streamdoc)
+    s2 = s1.map(myacc.increment)
+    s2.map(print)
+
+    sdoc = StreamDoc(args=(1,))
+    s1.emit(sdoc)
+    s1.emit(sdoc)
+    s1.emit(sdoc)
+    s1.emit(sdoc)
+
+def test_delayed():
+    ''' try making a delayed wrapper.'''
+    from dask import delayed
+    def myadder(a,b):
+        return a + b
+
+    def makenewdec(name):
+        def newdec(f):
+            @delayed(pure=True)
+            @parse_streamdoc(name)
+            def newf(*args, **kwargs):
+                return f(*args, **kwargs)
+            return newf
+        return newdec
+
+    def compute(obj):
+        return obj.compute()
+
+    def print_args(*args, **kwargs):
+        print("printing")
+        print("args : {}".format(args))
+        print("kwargs : {}".format(kwargs))
+
+    s1 = Stream(wrapper=makenewdec)
+    # map maps the unwrapped function, apply maps the wrapped function
+    s2 = s1.map(myadder)
+    s3 = s2.apply(compute)
+    s4 = s3.map(print_args)
+    s4.apply(compute)
+
+    sdoc = StreamDoc(args=(2,3))
     s1.emit(sdoc)

--- a/streams/tests/test_streamdoc.py
+++ b/streams/tests/test_streamdoc.py
@@ -1,0 +1,87 @@
+from nose.tools import assert_raises
+
+from streams.StreamDoc import StreamDoc, parse_streamdoc, _is_streamdoc
+from streams.core import Stream
+
+
+def test_type_check():
+    sdoc = StreamDoc()
+    assert(_is_streamdoc(sdoc))
+    sdoc = dict()
+    assert(not _is_streamdoc(sdoc))
+    sdoc = 1
+    assert(not _is_streamdoc(sdoc))
+
+
+def test_streamdoc_index():
+    ''' test that the various methods of selecting inputs/outputs of StreamDoc
+    work as intended.'''
+    sdoc = StreamDoc(args=(1, 2, 3, 4), kwargs=dict(foo="bar", a="fdfa"),
+                     attributes={"name": "cat"})
+
+    # one arg
+    assert(sdoc.select(1)['args'][0] == 2)
+    # list
+    assert(sdoc.select([0, 1])['args'][1] == 2)
+    # list of tuples
+    assert(sdoc.select([(1, ), (1, )])['args'][0] == 2)
+
+    # onekwarg
+    assert(sdoc.select('foo')['kwargs']['foo'] == 'bar')
+    # map a kwarg
+    assert(sdoc.select([('foo', 'foo')])['kwargs']['foo'] == 'bar')
+    assert(sdoc.select([('foo', 'bar')])['kwargs']['bar'] == 'bar')
+    # list of kwarg
+    assert(sdoc.select(['foo', 'a'])['kwargs']['foo'] == 'bar')
+
+    # map an arg to a kwarg
+    assert(sdoc.select((1, 'foo'))['kwargs']['foo'] == 2)
+    assert(sdoc.select([(1, 'foo')])['kwargs']['foo'] == 2)
+    # map a kwarg to an arg
+    assert(sdoc.select([('foo', None)])['args'][0] == 'bar')
+    assert(sdoc.select([('foo', None), ('a', None)])['args'][1] == 'fdfa')
+
+    assert_raises(ValueError, sdoc.select, ('foo', 1))
+    assert_raises(ValueError, sdoc.select, (1, 1))
+
+
+def test_streamdoc_dec():
+    @parse_streamdoc("test")
+    def foo(a, b, **kwargs):
+        return a+b
+
+    sdoc = StreamDoc(args=[1, 2])
+    res = foo(sdoc)
+    assert(res['args'][0] == 3)
+
+
+def test_with_streams():
+    def foo(a, b):
+        return a + b
+
+    # initialize the wrapper to understand streamdocs
+    s1 = Stream(wrapper=parse_streamdoc)
+    s2 = s1.map(foo)
+    s2.map(print)
+    s2.sink(print)
+
+    sdoc = StreamDoc(args=[1, 2])
+
+    s1.emit(sdoc)
+
+
+def test_with_stream_accumulator():
+    def accumfunc(prevstate, curstate):
+        ''' here prevstate just assumed an int.'''
+        return prevstate + curstate
+
+    # initialize the wrapper to understand streamdocs
+    s1 = Stream(wrapper=parse_streamdoc)
+    s2 = s1.accumulate(accumfunc)
+    s2.map(print)
+
+    sdoc = StreamDoc(args=[1])
+
+    s1.emit(sdoc)
+    s1.emit(sdoc)
+    s1.emit(sdoc)


### PR DESCRIPTION
Here's a suggestion for multiple arguments to streams: wrappers. Wrappers are functions that process the inputs before they're `map`ed or `accumulate`d. I think this is also analogous to network packets, where at each layer in the stack, you have the processing function unwrap the header of the data and pass through the data.

I include the ability to use wrappers in a way that should be backwards compatible with the streams idea (passes all tests included).

Wrappers are typically used with data that has a recongizable signature type. An example wrapper is included in here which included two main pieces:
1. StreamDoc.parse_streamdoc : the decorator to intercept the function
2. StreamDoc.StreamDoc : a StreamDoc object

The combination of the two serve as:
- An argument multiplexer :  to go around circumvent the one(two)
  argument(s) requirement of the mapping(accumulating) functions.
- An attibute container : to allow the passing of attributes to
  functions
- Statistics bookkeeping : to allow the passing of attributes that are
  specific to the instance of the processed stream but not specific to
  the data contained in the streams. For example, run start and run stop
  times would be useful to include here.

This is sort of what we use for our pipeline, except we don't use a streaming fashion (rather, we're looping over delayed objects). I like the streaming API in that it neatly abstracts the data from the pipeline in a better way.

I'd be interested to hear your thoughts, if this may be a potential extension to the library. I envisage if yes, it would require significant discussion/work as it's quite a big PR.

Thanks for the support!
