### PR TITLE
allow bound method zip to merge with more than one stream

### DIFF
--- a/streams/core.py
+++ b/streams/core.py
@@ -102,7 +102,8 @@ class Stream(object):
         return filter(predicate, self)
 
     def remove(self, predicate):
-        """ Only pass through elements for which the predicate returns False """
+        """ Only pass through elements for which the predicate returns False
+        """
         return filter(lambda x: not predicate(x), self)
 
     def accumulate(self, func, start=no_default):
@@ -240,9 +241,9 @@ class Stream(object):
         """
         return unique(self, history=history)
 
-    def zip(self, other):
+    def zip(self, *other):
         """ Combine two streams together into a stream of tuples """
-        return zip(self, other)
+        return zip(self, *other)
 
     def to_dask(self):
         """ Convert to a Dask Stream

--- a/streams/tests/test_core.py
+++ b/streams/tests/test_core.py
@@ -251,7 +251,6 @@ def test_zip():
     a.emit(1)
     b.emit(2)
     d.emit(3)
-    print(L2)
     assert L2 == [(1, 2, 3)]
 
 

--- a/streams/tests/test_core.py
+++ b/streams/tests/test_core.py
@@ -242,6 +242,17 @@ def test_zip():
     b.emit('b')
 
     assert L == [(1, 'a'), (2, 'b')]
+    d = Stream()
+    # test zip from the object itself
+    # zip 3 streams together
+    e = a.zip(b, d)
+    L2 = e.sink_to_list()
+
+    a.emit(1)
+    b.emit(2)
+    d.emit(3)
+    print(L2)
+    assert L2 == [(1, 2, 3)]
 
 
 def test_combine_latest():


### PR DESCRIPTION
from discussion in #8 . Allow multiple elements to be zipped.
for the record, the alternative is also:
```python
import streams as s
d = s.zip(a,b,c)
```

what is now allowed with this PR is also this:
```python
a = Stream()
b = Stream()
c = Stream()
# previous method
d = a.zip(b)
d = d.zip(c)

a = Stream()
b = Stream()
c = Stream()
# now this is allowed
d = a.zip(a,b,c)
```