### PR TITLE
Add __stream_map__, __stream_reduce__, and __stream_merge__ protocols

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+sudo: False
+
+language: python
+
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.6
+
+install:
+  # Install conda
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update conda
+
+  # Install dependencies
+  - conda create -n test-streams python=$TRAVIS_PYTHON_VERSION pytest tornado toolz flake8
+  - source activate test-streams
+
+  - python setup.py install
+
+script:
+  - py.test --doctest-modules streams
+  - flake8 streams
+
+notifications:
+  email: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+tornado
+toolz

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,49 @@
+[flake8]
+# References:
+# https://flake8.readthedocs.io/en/latest/user/configuration.html
+# https://flake8.readthedocs.io/en/latest/user/error-codes.html
+
+# Note: there cannot be spaces after comma's here
+exclude = __init__.py
+ignore =
+    # Extra space in brackets
+    E20,
+    # Multiple spaces around ","
+    E231,E241,
+    # Comments
+    E26,
+    # Import formatting
+    E4,
+    # Comparing types instead of isinstance
+    E721,
+    # Assigning lambda expression
+    E731,
+    # continuation line under-indented for hanging indent
+    E121,
+    # continuation line over-indented for hanging indent
+    E126,
+    # continuation line over-indented for visual indent
+    E127,
+    # E128 continuation line under-indented for visual indent
+    E128,
+    # multiple statements on one line (semicolon)
+    E702,
+    # line break before binary operator
+    W503,
+    # visually indented line with same indent as next logical line
+    E129,
+    # unexpected indentation
+    E116 
+
+max-line-length = 120
+
+[versioneer]
+VCS = git
+style = pep440
+versionfile_source = distributed/_version.py
+versionfile_build = distributed/_version.py
+tag_prefix =
+parentdir_prefix = distributed-
+
+[bdist_wheel]
+universal=1

--- a/streams/core.py
+++ b/streams/core.py
@@ -1,11 +1,10 @@
 from collections import deque
-import math
 from time import time
 
 import toolz
 from tornado import gen
 from tornado.locks import Condition
-from tornado.ioloop import IOLoop, PeriodicCallback
+from tornado.ioloop import IOLoop
 from tornado.queues import Queue
 
 

--- a/streams/core.py
+++ b/streams/core.py
@@ -203,6 +203,14 @@ class Stream(object):
         """ Add a time delay to results """
         return delay(interval, self, loop=None)
 
+    def combine_latest(self, *others):
+        """ Combine multiple streams together to a stream of tuples
+
+        This will emit a new tuple of all of the most recent elements seen from
+        any stream.
+        """
+        return combine_latest(self, *others)
+
     def concat(self):
         """ Flatten streams of lists or iterables into a stream of elements
 

--- a/streams/core.py
+++ b/streams/core.py
@@ -224,6 +224,20 @@ class Stream(object):
 
     flatten = concat
 
+    def union(self, *others):
+        """ Combine multiple streams into one
+
+        Every element from any of the children streams will immediately flow
+        into the output stream.  They will not be combined with elements from
+        other streams.
+
+        See also
+        --------
+        Stream.zip
+        Stream.combine_latest
+        """
+        return union(children=(self,) + others)
+
     def unique(self, history=None, key=identity):
         """ Avoid sending through repeated elements
 
@@ -540,3 +554,8 @@ class unique(Stream):
         if y not in self.seen:
             self.seen[y] = 1
             return self.emit(x)
+
+
+class union(Stream):
+    def update(self, x, who=None):
+        return self.emit(x)

--- a/streams/core.py
+++ b/streams/core.py
@@ -316,14 +316,15 @@ class Sink(Stream):
 
 
 class map(Stream):
-    def __init__(self, func, child, **kwargs):
+    def __init__(self, func, child, raw=False, **kwargs):
         self.func = func
         self.kwargs = kwargs
+        self.raw = raw
 
         Stream.__init__(self, child)
 
     def update(self, x, who=None):
-        if hasattr(x, '__stream_map__'):
+        if not self.raw and hasattr(x, '__stream_map__'):
             result = x.__stream_map__(self.func, **self.kwargs)
         else:
             result = self.func(x, **self.kwargs)

--- a/streams/dask.py
+++ b/streams/dask.py
@@ -3,7 +3,6 @@ from tornado.locks import Condition
 from tornado.queues import Queue
 from tornado import gen
 
-from . import core
 from .core import Stream
 
 

--- a/streams/dask.py
+++ b/streams/dask.py
@@ -1,4 +1,4 @@
-from distributed.client import default_client
+from distributed.client import default_client, Future
 from tornado.locks import Condition
 from tornado.queues import Queue
 from tornado import gen
@@ -7,55 +7,19 @@ from . import core
 from .core import Stream
 
 
-class DaskStream(Stream):
-    """ A Stream of Dask futures
-
-    This follows a subset of the Stream API but operates on a cluster
-
-    Examples
-    --------
-    >>> from dask.distributed import Client
-    >>> client = Client()
-    >>> source = Stream()
-    >>> s = source.to_dask().map(func).gather()
-    """
-    def map(self, func, **kwargs):
-        """ Apply a function on every element of the stream with Dask
-
-        This uses ``Client.submit`` to call a function on the element
-        asynchronously on a Dask cluster.  It returns a stream of futures.
-        """
-        return map(func, self, **kwargs)
-
-    def scan(self, func, start=core.no_default):
-        """ Accumulate results with previous state
-
-        This uses ``Client.submit`` to call the function using a Dask client.
-        It returns a stream of futures.
-        """
-        return scan(func, self, start=start)
-
-    accumulate = scan
-
-    def scatter(self, limit=10, client=None):
-        """ Scatter data out to a cluster
-
-        This returns a stream of futures
-        """
-        return scatter(self, limit=limit, client=client)
-
-    def gather(self, limit=10, client=None):
-        """ Gather a stream of futures back to a stream of local results """
-        return gather(self, limit=limit, client=client)
-
-    def update(self, x, who=None):
-        return self.emit(x)
-
-    def zip(self, other):
-        return zip(self, other)
+def __stream_map__(self, func):
+    return default_client().submit(func, self)
 
 
-class scatter(DaskStream):
+def __stream_reduce__(self, func, accumulator):
+    return default_client().submit(func, accumulator, self)
+
+
+Future.__stream_map__ = __stream_map__
+Future.__stream_reduce__ = __stream_reduce__
+
+
+class scatter(Stream):
     def __init__(self, child, limit=10, client=None):
         self.client = client or default_client()
         self.queue = Queue(maxsize=limit)
@@ -117,34 +81,3 @@ class gather(Stream):
     def flush(self):
         while not self.queue.empty():
             yield self.condition.wait()
-
-
-class map(DaskStream):
-    def __init__(self, func, child, client=None, **kwargs):
-        self.client = client or default_client()
-        self.func = func
-        self.kwargs = kwargs
-
-        Stream.__init__(self, child)
-
-    def update(self, x, who=None):
-        return self.emit(self.client.submit(self.func, x, **self.kwargs))
-
-
-class scan(DaskStream):
-    def __init__(self, func, child, start=core.no_default, client=None):
-        self.client = client or default_client()
-        self.func = func
-        self.state = start
-
-        Stream.__init__(self, child)
-
-    def update(self, x, who=None):
-        if self.state is core.no_default:
-            self.state = x
-        else:
-            self.state = self.client.submit(self.func, self.state, x)
-            return self.emit(self.state)
-
-class zip(core.zip, DaskStream):
-    pass

--- a/streams/sources.py
+++ b/streams/sources.py
@@ -1,6 +1,5 @@
 from .core import Stream, Sink
 from tornado import gen
-from tornado.ioloop import IOLoop
 
 
 def inc(x):
@@ -32,7 +31,7 @@ def sink_to_file(filename, child, mode='w', prefix='', suffix='\n', flush=False)
         if flush:
             file.flush()
 
-    sink = Sink(write, child)
+    Sink(write, child)
     return file
 
 

--- a/streams/tests/test_core.py
+++ b/streams/tests/test_core.py
@@ -324,6 +324,19 @@ def test_unique():
     assert L == [1, 2]
 
 
+def test_unique_key():
+    source = Stream()
+    L = source.unique(key=lambda x: x % 2, history=1).sink_to_list()
+
+    source.emit(1)
+    source.emit(2)
+    source.emit(4)
+    source.emit(6)
+    source.emit(3)
+
+    assert L == [1, 2, 3]
+
+
 def test_unique_history():
     source = Stream()
     s = source.unique(history=2)

--- a/streams/tests/test_core.py
+++ b/streams/tests/test_core.py
@@ -359,3 +359,20 @@ def test_unique_history():
     source.emit(1)
 
     assert L == [1, 2, 3, 1]
+
+
+def test_union():
+    a = Stream()
+    b = Stream()
+    c = Stream()
+
+    L = a.union(b, c).sink_to_list()
+
+    a.emit(1)
+    assert L == [1]
+    b.emit(2)
+    assert L == [1, 2]
+    a.emit(3)
+    assert L == [1, 2, 3]
+    c.emit(4)
+    assert L == [1, 2, 3, 4]

--- a/streams/tests/test_core.py
+++ b/streams/tests/test_core.py
@@ -257,7 +257,7 @@ def test_zip():
 def test_combine_latest():
     a = Stream()
     b = Stream()
-    c = s.combine_latest(a, b)
+    c = a.combine_latest(b)
 
     L = c.sink_to_list()
 

--- a/streams/tests/test_dask.py
+++ b/streams/tests/test_dask.py
@@ -1,17 +1,10 @@
 from operator import add
-from time import time
-
-import pytest
 
 from distributed.client import Future
-from distributed.utils_test import inc, double, gen_test, gen_cluster
-from distributed.utils import tmpfile
-from tornado import gen
-from tornado.queues import Queue
+from distributed.utils_test import inc, gen_cluster
 
-from ..core import *
+from streams.core import Stream
 import streams.dask as ds
-from ..sources import *
 
 
 @gen_cluster(client=True)

--- a/streams/tests/test_protocols.py
+++ b/streams/tests/test_protocols.py
@@ -31,6 +31,19 @@ def test_map():
     assert L[0].data == 2
 
 
+def test_map_raw():
+    source = Stream()
+    L = source.map(lambda x: (x, x), raw=True).sink_to_list()
+
+    f = Foo(1)
+    source.emit(f)
+
+    assert isinstance(L[0], tuple)
+    assert len(L[0]) == 2
+    assert L[0][0] is f
+    assert L[0][1] is f
+
+
 def test_scan():
     source = Stream()
     L = source.scan(add).sink_to_list()

--- a/streams/tests/test_protocols.py
+++ b/streams/tests/test_protocols.py
@@ -1,0 +1,55 @@
+from operator import add
+
+from streams import Stream
+
+
+def inc(x):
+    return x + 1
+
+
+class Foo(object):
+    def __init__(self, data):
+        self.data = data
+
+    def __stream_map__(self, func):
+        return Foo(func(self.data))
+
+    def __stream_reduce__(self, func, accumulator):
+        return Foo(func(accumulator.data, self.data))
+
+    def __stream_merge__(self, *others):
+        return Foo((self.data,) + tuple(o.data for o in others))
+
+
+def test_map():
+    source = Stream()
+    L = source.map(inc).sink_to_list()
+
+    source.emit(Foo(1))
+
+    assert isinstance(L[0], Foo)
+    assert L[0].data == 2
+
+
+def test_scan():
+    source = Stream()
+    L = source.scan(add).sink_to_list()
+
+    source.emit(Foo(1))
+    source.emit(Foo(2))
+    source.emit(Foo(3))
+
+    assert isinstance(L[1], Foo)
+    assert L[1].data == 6
+
+
+def test_zip():
+    a = Stream()
+    b = Stream()
+
+    L = a.zip(b).sink_to_list()
+
+    a.emit(Foo(1))
+    b.emit(Foo(2))
+
+    assert L[0].data == (1, 2)


### PR DESCRIPTION
This allows objects within a stream to take control of map, accumulate, and
combination operations (like zip, combine_latest).  I *hope* that this helps to
resolve problems around dask, metadata tracking, batching, etc..

cc @ordirules @danielballan