### PR TITLE
Scan state and map-args

### DIFF
--- a/streams/core.py
+++ b/streams/core.py
@@ -96,9 +96,9 @@ class Stream(object):
         self._loop = IOLoop.current()
         return self._loop
 
-    def map(self, func, **kwargs):
+    def map(self, func, *args, **kwargs):
         """ Apply a function to every element in the stream """
-        return map(func, self, **kwargs)
+        return map(func, self, args=args, **kwargs)
 
     def filter(self, predicate):
         """ Only pass through elements that satisfy the predicate """
@@ -350,15 +350,16 @@ class Sink(Stream):
 
 
 class map(Stream):
-    def __init__(self, func, child, raw=False, **kwargs):
+    def __init__(self, func, child, raw=False, args=(), **kwargs):
         self.func = func
         self.kwargs = kwargs
         self.raw = raw
+        self.args = args
 
         Stream.__init__(self, child)
 
     def update(self, x, who=None):
-        result = self.func(x, **self.kwargs)
+        result = self.func(x, *self.args, **self.kwargs)
 
         return self.emit(result)
 

--- a/streams/tests/test_core.py
+++ b/streams/tests/test_core.py
@@ -35,6 +35,7 @@ def test_basic():
 
 def test_scan():
     source = Stream()
+
     def f(acc, i):
         acc = acc + i
         return acc, acc

--- a/streams/tests/test_core.py
+++ b/streams/tests/test_core.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+import operator
 from operator import add
 from time import time
 
@@ -65,6 +66,13 @@ def test_map():
     source.emit(1)
 
     assert L[0] == 11
+
+
+def test_map_args():
+    source = Stream()
+    L = source.map(operator.add, 10).sink_to_list()
+    source.emit(1)
+    assert L == [11]
 
 
 def test_remove():

--- a/streams/tests/test_core.py
+++ b/streams/tests/test_core.py
@@ -32,6 +32,19 @@ def test_basic():
     assert Lb == [0, 2, 4, 6]
 
 
+def test_scan():
+    source = Stream()
+    def f(acc, i):
+        acc = acc + i
+        return acc, acc
+
+    L = source.scan(f, returns_state=True).sink_to_list()
+    for i in range(3):
+        source.emit(i)
+
+    assert L == [1, 3]
+
+
 def test_filter():
     source = Stream()
     L = source.filter(lambda x: x % 2 == 0).sink_to_list()


### PR DESCRIPTION
This allows scan/accumulate functions to return the state as well as an output.

This also allows `*args` in `map`