### PR TITLE
API : Changed default behaviour for scan method.

### DIFF
--- a/streams/core.py
+++ b/streams/core.py
@@ -419,6 +419,7 @@ class scan(Stream):
     def update(self, x, who=None):
         if self.state is no_default:
             self.state = x
+            return self.emit(x)
         else:
             result = self.func(self.state, x)
             if self.returns_state:

--- a/streams/tests/test_core.py
+++ b/streams/tests/test_core.py
@@ -29,7 +29,7 @@ def test_basic():
     for i in range(4):
         source.emit(i)
 
-    assert Lc == [3, 6, 10]
+    assert Lc == [1, 3, 6, 10]
     assert Lb == [0, 2, 4, 6]
 
 
@@ -44,7 +44,7 @@ def test_scan():
     for i in range(3):
         source.emit(i)
 
-    assert L == [1, 3]
+    assert L == [0, 1, 3]
 
 
 def test_filter():


### PR DESCRIPTION
I would prefer the accumulator emitting a result on the first iteration. I know it's an API change, but the library is still young. Was there a motivation to choose otherwise? (note this would affect dask scan as well)